### PR TITLE
Update Filter - Case Insensitive

### DIFF
--- a/src/aura/PowerRelatedList2/PowerRelatedList2Helper.js
+++ b/src/aura/PowerRelatedList2/PowerRelatedList2Helper.js
@@ -68,7 +68,7 @@
             var goodStuff = _.filter(component.get("v.results"), function(record){
                 var contains = false;
                 _.forEach(record, function (value){
-                    contains = contains || _.includes(_.toString(value), filter);
+                    contains = contains || _.includes(_.toString(value).toLowerCase(), filter.toLowerCase());
                 });
                 return contains;
             });


### PR DESCRIPTION
The filter function was not taking into account the _.includes is case sensitive. Making the string lowercase and the filter lowercase ensures results are returned as expected.